### PR TITLE
OPS-1216: declare service_account variable. so it doesnt default to "…

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -13,3 +13,8 @@ variable "attribute_condition" {
   type        = string
   default     = "assertion.repository_owner=='NorddeutscherRundfunk'"
 }
+
+variable "service_accounts" {
+  description = "Bucket service accounts (read-write)"
+  type        = set(string)
+}


### PR DESCRIPTION
…tf-github"

Die [Pipeline](https://gitlab.com/ndrde/gcp/ndr.de/ndrfragt/ndrfragt/-/jobs/7953980964#L97) failed, da es den serviceaccount "tf-github" doppelt gibt. Der serviceaccount ist hardcoded in diesem Modul